### PR TITLE
docs: add Left on Read to app showcase

### DIFF
--- a/docs/app-showcase.md
+++ b/docs/app-showcase.md
@@ -6,14 +6,6 @@ sidebar_label: App Showcase
 
 Here are some awesome apps that are based on Electron React Boilerplate!
 
-## Left on Read (Open Source)
-
-[Link](https://github.com/Left-on-Read/leftonread)
-
-[**Analytics and productivity tools for your iMessages**](https://leftonread.me/)
-
-![leftonread](/img/app-showcase/left-on-read.gif)
-
 ## Command E
 
 ![command e](/img/app-showcase/cmde.png)
@@ -115,3 +107,11 @@ Instantly find everything you need to work faster, on your desktop and across yo
 [**A tool to build & flash ExpressLRS RC Link firmware**](https://github.com/ExpressLRS/ExpressLRS-Configurator)
 
 ![ExpressLRS Configurator](/img/app-showcase/expresslrs-configurator.jpg)
+
+## Left on Read (Open Source)
+
+[Link](https://github.com/Left-on-Read/leftonread)
+
+[**Analytics and productivity tools for your iMessages**](https://leftonread.me/)
+
+![leftonread](/img/app-showcase/left-on-read.gif)

--- a/docs/app-showcase.md
+++ b/docs/app-showcase.md
@@ -6,6 +6,14 @@ sidebar_label: App Showcase
 
 Here are some awesome apps that are based on Electron React Boilerplate!
 
+## Left on Read (Open Source)
+
+[Link](https://github.com/Left-on-Read/leftonread)
+
+[**Analytics and productivity tools for your iMessages**](https://leftonread.me/)
+
+![leftonread](/img/app-showcase/left-on-read.gif)
+
 ## Command E
 
 ![command e](/img/app-showcase/cmde.png)


### PR DESCRIPTION
Adds the open-source project Left on Read to the app showcase. Also pusgubg a .gif that says "Built with Electron React Boilerplate". (Got the idea of a gif from popsql and was worried an external link might break in the future.)

Left on Read is an example of an ERB project with sqlite: https://github.com/Left-on-Read/leftonread

Above all, thanks for your consideration, @amilajack we actually had a "github discussion" back in 2020 regarding why v2.0.0 was removing testcafe and e2e tests, but seems the link has since expired. Time flies! 

Regardless of this PR, we are very grateful for Electron React Boilerplate. Let me know if there's anything you'd like me to change or anyway our project can support yours.

![left-on-read](https://user-images.githubusercontent.com/29822597/190061719-0be6541b-7ac4-4987-a662-c0c377e2a06d.gif)
