### PR TITLE
Make playwright test run on MacOS

### DIFF
--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -54,6 +54,11 @@ test.describe.serial(() => {
   });
 
   test.afterAll(async () => {
+    // On MacOS, close window first
+    if (process.platform === "darwin") {
+      const window = await electronApp.firstWindow();
+      await window.close();
+     }
     await electronApp.close();
   });
 


### PR DESCRIPTION
In the default config, the app doesn't close on macOS if all windows are closed.