### PR TITLE
Remove note about electron-builder options

### DIFF
--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -12,13 +12,6 @@ npm run package
 
 The packaged app will be inside the `release` directory.
 
-To package apps with options:
-
-```bash
-npm run package -- --[option]
-# Example: npm run package -- --mac
-```
-
 ### Debugging Production Builds
 
 You can debug your production build with devtools by simply setting the `DEBUG_PROD` env variable


### PR DESCRIPTION
At the moment, this does not work out of the box. For now let's prevent confusion by removing this from the docs. Many issues are assuming this works when it doesn't. Example: https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues/3554